### PR TITLE
Updated code compatability with packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .DS_Store
+LA/Baseline-LFCC-GMM/python/lfcc.h5
+LA/Baseline-LFCC-GMM/python/__pycache__/gmm.cpython-37.pyc
+LA/Baseline-LFCC-GMM/python/__pycache__/LFCC_pipeline.cpython-37.pyc
+LA/Baseline-LFCC-GMM/python/gmm_LA_lfcc.pkl_bonafide_init_partial.pkl

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ LA/Baseline-LFCC-GMM/python/lfcc.h5
 LA/Baseline-LFCC-GMM/python/__pycache__/gmm.cpython-37.pyc
 LA/Baseline-LFCC-GMM/python/__pycache__/LFCC_pipeline.cpython-37.pyc
 LA/Baseline-LFCC-GMM/python/gmm_LA_lfcc.pkl_bonafide_init_partial.pkl
+LA/Baseline-LFCC-GMM/python/gmm_LA_lfcc.pkl
+LA/Baseline-LFCC-GMM/python/gmm_LA_lfcc.pkl_spoof_init_partial.pkl
+LA/Baseline-LFCC-GMM/python/gmm_lfcc_asvspoof21_la.pkl

--- a/LA/Baseline-LFCC-GMM/python/LFCC_pipeline.py
+++ b/LA/Baseline-LFCC-GMM/python/LFCC_pipeline.py
@@ -1,9 +1,9 @@
+import scipy.fftpack
 from spafe.utils.preprocessing import pre_emphasis, framing, windowing, zero_handling
 from spafe.utils.exceptions import ParameterError, ErrorMsgs
 from spafe.fbanks.linear_fbanks import linear_filter_banks
-from spafe.utils.cepstral import cms, cmvn, lifter_ceps
-from spafe.utils.spectral import dct, power_spectrum
 from librosa import util
+import scipy
 import numpy as np
 
 
@@ -93,7 +93,16 @@ def lfcc(sig,
     abs_fft_values = np.abs(fourrier_transform)**2
 
     #  -> x linear-fbanks
-    linear_fbanks_mat = linear_filter_banks(nfilts=nfilts,
+    # 
+    # Old spafe docs
+    # (numpy array) array of size nfilts * (nfft/2 + 1) containing filterbank. Each row holds 1 filter.
+
+    # New spafe docs
+    # (numpy.ndarray) : array of size nfilts * (nfft/2 + 1) containing filter bank. Each row holds 1 filter.
+    # (numpy.ndarray) : array of center frequencies
+
+    # _ the second element of the tuple because it is not needed.
+    linear_fbanks_mat, _ = linear_filter_banks(nfilts=nfilts,
                                             nfft=nfft,
                                             fs=fs,
                                             low_freq=low_freq,
@@ -105,6 +114,6 @@ def lfcc(sig,
     log_features = np.log10(features+2.2204e-16)
 
     #  -> DCT(.)
-    lfccs=dct(log_features, type=dct_type, norm='ortho', axis=1)[:, :num_ceps ]
+    lfccs=scipy.fftpack.dct(log_features, type=dct_type, norm='ortho', axis=1)[:, :num_ceps ]
 
     return lfccs

--- a/LA/Baseline-LFCC-GMM/python/LFCC_pipeline.py
+++ b/LA/Baseline-LFCC-GMM/python/LFCC_pipeline.py
@@ -1,4 +1,3 @@
-import scipy.fftpack
 from spafe.utils.preprocessing import pre_emphasis, framing, windowing, zero_handling
 from spafe.utils.exceptions import ParameterError, ErrorMsgs
 from spafe.fbanks.linear_fbanks import linear_filter_banks

--- a/LA/Baseline-LFCC-GMM/python/LFCC_pipeline.py
+++ b/LA/Baseline-LFCC-GMM/python/LFCC_pipeline.py
@@ -2,7 +2,7 @@ from spafe.utils.preprocessing import pre_emphasis, framing, windowing, zero_han
 from spafe.utils.exceptions import ParameterError, ErrorMsgs
 from spafe.fbanks.linear_fbanks import linear_filter_banks
 from librosa import util
-import scipy
+from scipy import fftpack
 import numpy as np
 
 
@@ -113,6 +113,6 @@ def lfcc(sig,
     log_features = np.log10(features+2.2204e-16)
 
     #  -> DCT(.)
-    lfccs=scipy.fftpack.dct(log_features, type=dct_type, norm='ortho', axis=1)[:, :num_ceps ]
+    lfccs=fftpack.dct(log_features, type=dct_type, norm='ortho', axis=1)[:, :num_ceps ]
 
     return lfccs

--- a/LA/Baseline-LFCC-GMM/python/gmm.py
+++ b/LA/Baseline-LFCC-GMM/python/gmm.py
@@ -1,4 +1,4 @@
-from numpy import log, exp, infty, zeros_like, vstack, zeros, errstate, finfo, sqrt, floor, tile, concatenate, arange, meshgrid, ceil, linspace
+from numpy import log, exp, inf, zeros_like, vstack, zeros, errstate, finfo, sqrt, floor, tile, concatenate, arange, meshgrid, ceil, linspace
 from sklearn.mixture import GaussianMixture
 from scipy.special import logsumexp
 from scipy.signal import lfilter

--- a/LA/Baseline-LFCC-GMM/python/gmm_scoring_asvspoof21.py
+++ b/LA/Baseline-LFCC-GMM/python/gmm_scoring_asvspoof21.py
@@ -8,11 +8,7 @@ scores_file = 'scores-lfcc-asvspoof21-LA.txt'
 features = 'lfcc'
 dict_file = 'gmm_lfcc_asvspoof21_la.pkl'
 
-<<<<<<< HEAD
 db_folder = '/path/to/ASVspoof_root/'  # put your database root path here
-=======
-db_folder = ''  # put your database root path here
->>>>>>> c8f7e744ef95f4df5d225292fe3f902ed32ca6f1
 eval_folder = db_folder + 'LA/ASVspoof2021_LA_eval/flac/'
 eval_ndx = db_folder + 'LA/ASVspoof2021_LA_cm_protocols/ASVspoof2021.LA.cm.eval.trl.txt'
 


### PR DESCRIPTION
Updated .gitingore

Spfae Docs have been updated and do not include functions cms, cmvn, dct, etc ( these were also unused )
Scipy has a dct function that works with the same arguements.

New spafe docs: https://superkogito.github.io/spafe/

Numpy no longer supports infty. Has been switched to inf (source: https://numpy.org/devdocs/reference/constants.html#numpy.inf)

From the spafe documentation linear_filter_banks use to return "(numpy array) array of size nfilts * (nfft/2 + 1) containing filterbank. Each row holds 1 filter." but now returns tuple of "(numpy.ndarray) : array of size nfilts * (nfft/2 + 1) containing filter bank. Each row holds 1 filter." and "(numpy.ndarray) : array of center frequencies". 

Since the original code only used the first numpy array I simply disregarded the second value of the tuple

Unresolved merge conflict resolved.